### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ After installing golang and cloning this repository, download all the go depende
 
     $ cd mstat
     $ go get -d ./...
+    $ make
 
 Then proceed with make and installation. If you want to be able to uninstall
 `mstat` later, instead of using `make install`, use the command below


### PR DESCRIPTION
Before running ```sudo checkinstall```, it is necessary to run ```make```, otherwise the checkinstall command fails with the following message:
>install: cannot stat 'mstat': No such file or directory
>Makefile:28: recipe for target 'install' failed